### PR TITLE
fix(mat-quill): empty check for floating mat label returns opposite

### DIFF
--- a/src/app/mat-quill/mat-quill-base.ts
+++ b/src/app/mat-quill/mat-quill-base.ts
@@ -135,7 +135,7 @@ export abstract class _MatQuillBase
   disabled = false
 
   get empty() {
-    return coerceBooleanProperty(this.value)
+    return !coerceBooleanProperty(this.value)
   }
 
   @Input()


### PR DESCRIPTION
When I put `mat-quill` inside a `mat-form-field` with a floating label, when the Quill editor is empty and not focused the label floats, and when it contains any change the label overlaps the editor.

``` typescript
function coerceBooleanProperty(value) {
    return value != null && `${value}` !== 'false';
}
```

Based on the logic of `coerceBooleanProperty`, `empty()` should return the negation of its returned value.