### PR TITLE
fix(mat-quill): error state not updated on initial blur

### DIFF
--- a/src/app/mat-quill/mat-quill-base.ts
+++ b/src/app/mat-quill/mat-quill-base.ts
@@ -110,7 +110,8 @@ export abstract class _MatQuillBase
     this.blurSubscription = this.onBlur.subscribe(() => {
       this.focused = false
       if (!!this.ngControl && !this.ngControl.control.touched) {
-        this.ngControl.control.markAsTouched();
+        this.ngControl.control.markAsTouched()
+        this.updateErrorState()
       }
       this.stateChanges.next()
     })


### PR DESCRIPTION
If a `mat-quill` is focused for the first time and then loses focus with a validation error, a `mat-error` hint does not show.

The control must be marked as touched and then `updateErrorState()` called to behave like other Angular Material form elements so that the `mat-error` hint shows on initial focus/blur.