### PR TITLE
Add missing katex configuration for math formulas

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,20 @@
       languages: ['javascript', 'ruby', 'bash']
     });
   </script>
+  
+  <!-- Math formulas support -->
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css"
+    integrity="sha384-RZU/ijkSsFbcmivfdRBQDtwuwVqK7GMOw6IMvKyeWL2K5UAlyp6WonmB8m7Jd0Hn"
+    crossorigin="anonymous"
+  />
+  <script
+    defer
+    src="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.js"
+    integrity="sha384-pK1WpvzWVBQiP0/GjnvRxV4mOb0oxFuyRxJlk6vVw146n3egcN5C925NCP7a7BY8"
+    crossorigin="anonymous"
+  ></script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
It is mentioned in this `/app/formula/formula.component.html#L2` , however the configuration is not present