### PR TITLE
Use CommonModule instead of BrowserModule

### DIFF
--- a/src/app/mat-quill/mat-quill-module.ts
+++ b/src/app/mat-quill/mat-quill-module.ts
@@ -10,7 +10,7 @@ import { MatQuill } from './mat-quill'
   declarations: [MatQuill],
   exports: [MatQuill],
   imports: [
-    BrowserModule,
+    CommonModule,
     FormsModule,
     ReactiveFormsModule,
     QuillModule,


### PR DESCRIPTION
BrowserModules re exports CommonModule and should only be imported once in the app.module.ts